### PR TITLE
docs(typescript): updated documentation about module augmentation

### DIFF
--- a/examples/codesandbox-starter-typescript/.babelrc
+++ b/examples/codesandbox-starter-typescript/.babelrc
@@ -1,0 +1,15 @@
+{
+  "presets": [
+    "@babel/preset-env",
+    "@babel/preset-typescript",
+    [
+      "@babel/preset-react",
+      {
+        "throwIfNamespace": false,
+        "runtime": "automatic",
+        "importSource": "theme-ui"
+      }
+    ]
+  ]
+}
+

--- a/examples/codesandbox-starter-typescript/.prettierrc
+++ b/examples/codesandbox-starter-typescript/.prettierrc
@@ -1,0 +1,11 @@
+{
+  "printWidth": 80,
+  "tabWidth": 2,
+  "useTabs": false,
+  "semi": false,
+  "singleQuote": true,
+  "trailingComma": "es5",
+  "bracketSpacing": true,
+  "jsxBracketSameLine": false,
+  "fluid": false
+}

--- a/examples/codesandbox-starter-typescript/custom-types/theme-ui.d.ts
+++ b/examples/codesandbox-starter-typescript/custom-types/theme-ui.d.ts
@@ -1,0 +1,5 @@
+import { ExactTheme } from '../src/theme'
+
+declare module '@theme-ui/css' {
+  interface UserTheme extends ExactTheme {}
+}

--- a/examples/codesandbox-starter-typescript/index.html
+++ b/examples/codesandbox-starter-typescript/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Theme UI Sandbox</title>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+  </head>
+
+  <body>
+    <div id="root"></div>
+
+    <script src="src/index.tsx"></script>
+  </body>
+</html>

--- a/examples/codesandbox-starter-typescript/package.json
+++ b/examples/codesandbox-starter-typescript/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "theme-ui-starter-typescript",
+  "private": "true",
+  "version": "0.6.0-alpha.4",
+  "description": "A TypeScript sandbox configured with Theme UI, including the `base` theme.",
+  "main": "index.html",
+  "scripts": {
+    "start": "parcel index.html --open",
+    "build": "parcel build index.html"
+  },
+  "dependencies": {
+    "@emotion/react": "^11.1.4",
+    "@mdx-js/react": "^1.6.22",
+    "@theme-ui/presets": "^0.6.0-alpha.4",
+    "react": "^17.0.1",
+    "react-dom": "^17.0.1",
+    "theme-ui": "^0.6.0-alpha.4"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.12.10",
+    "@babel/plugin-transform-react-jsx": "^7.12.12",
+    "@babel/plugin-transform-runtime": "^7.12.10",
+    "@babel/preset-env": "^7.12.11",
+    "@babel/preset-react": "^7.12.10",
+    "@babel/preset-typescript": "^7.12.7",
+    "@types/react": "17.0.0",
+    "@types/react-dom": "17.0.0",
+    "parcel-bundler": "^1.12.4",
+    "typescript": "4.1.3"
+  },
+  "keywords": [
+    "react",
+    "typescript",
+    "theme-ui",
+    "starter",
+    "styled-system"
+  ]
+}

--- a/examples/codesandbox-starter-typescript/src/index.tsx
+++ b/examples/codesandbox-starter-typescript/src/index.tsx
@@ -1,0 +1,21 @@
+/** @jsxImportSource theme-ui */
+
+import ReactDOM from 'react-dom'
+import { Themed } from 'theme-ui'
+
+import ThemeProvider, { Reset } from './theme'
+
+function App() {
+  return (
+    <ThemeProvider>
+      <div sx={{ p: 3 }}>
+        <Reset />
+        <Themed.h1 sx={{ color: 'primary', mb: 3 }}>Hello Theme UI</Themed.h1>
+        <Themed.p>Start editing to see some magic happen!</Themed.p>
+      </div>
+    </ThemeProvider>
+  )
+}
+
+const rootElement = document.getElementById('root')
+ReactDOM.render(<App />, rootElement)

--- a/examples/codesandbox-starter-typescript/src/theme.tsx
+++ b/examples/codesandbox-starter-typescript/src/theme.tsx
@@ -1,0 +1,33 @@
+/** @jsxImportSource theme-ui */
+
+import { Global } from '@emotion/react'
+import { createElement, memo } from 'react'
+import { ThemeProvider, Themed } from 'theme-ui'
+// todo: move to theme-ui import
+import { makeTheme } from '../../../packages/css/src/exact-theme';
+
+const customTheme = makeTheme({
+  colors: {
+    primary: 'red',
+    'primary-dark': 'darkred'
+  }
+});
+
+export type ExactTheme = typeof customTheme;
+
+const CustomThemeProvider = memo(({ children, ...props }) => (
+  <ThemeProvider theme={customTheme} {...props}>
+    <Themed.root>{children}</Themed.root>
+  </ThemeProvider>
+))
+
+const Reset = () =>
+  createElement(Global, {
+    styles: {
+      body: {
+        margin: '0',
+      },
+    },
+  })
+
+export { Reset, CustomThemeProvider as default }

--- a/examples/codesandbox-starter-typescript/tsconfig.json
+++ b/examples/codesandbox-starter-typescript/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "outDir": "dist",
+    "module": "esnext",
+    "target": "es5",
+    "lib": ["es2015", "dom"],
+    "sourceMap": true,
+    "jsx": "react",
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "moduleResolution": "node",
+    "forceConsistentCasingInFileNames": true,
+    "typeRoots": ["node_modules", "custom-types"]
+  }
+}

--- a/packages/css/src/types.ts
+++ b/packages/css/src/types.ts
@@ -34,7 +34,7 @@ export type CSSPseudoSelectorProps = { [K in CSS.Pseudos]?: ThemeUIStyleObject }
 
 /**
  * Can be augmented by users to inject their exact theme into Theme UI types.
- * @see TODO LINK TO THE DOCS
+ * @see https://theme-ui.com/guides/typescript#extending-the-theme
  */
 export interface UserTheme {}
 

--- a/packages/docs/src/pages/guides/typescript.mdx
+++ b/packages/docs/src/pages/guides/typescript.mdx
@@ -16,19 +16,7 @@ If you need additional properties in the theme object,
 you can add them with [module augmentation](https://www.typescriptlang.org/docs/handbook/declaration-merging.html#module-augmentation).
 
 ```tsx
-import { makeTheme } from '@theme-ui/css';
-
-interface MyTheme {
-  colors: {
-    primary: string;
-    'primary-dark': string;
-    'primary-light': string;
-  }
-}
-
-declare module '@theme-ui/css' {
-  interface UserTheme extends MyTheme {}
-}
+import { makeTheme } from 'theme-ui'
 
 const theme = makeTheme({
   colors: {
@@ -37,13 +25,25 @@ const theme = makeTheme({
     'primary-light': 'pink'
   },
 })
+
+export type MyTheme = typeof theme;
+```
+
+custom d.ts file:
+
+```ts
+import { MyTheme } from '~/myCustomTheme'
+
+declare module '@theme-ui/css' {
+  interface UserTheme extends MyTheme {}
+}
 ```
 
 Theme UI’s `Theme` interface will automatically pick up customizations to the
 internal `UserTheme` so you will be free to reference your custom properties:
 
-```tsx
-import { css } from '@theme-ui/css';
+```ts
+import { css } from 'theme-ui'
 
 const primaryDarkColor = css({
   color: 'primary-dark' // auto-completes and no error
@@ -58,12 +58,20 @@ or
 const H2 = () => <h2 sx={{ color: 'primary' }}>primary heading</h2>
 ````
 
-## Accessing optional properties
+When accessing the theme, you can use the `get` helper to avoid having
+excessive optional chaining when accessing theme properties. This
+can be useful if your theme is dynamically constructed at runtime,
+and the exact shape cannot be guaranteed.
+
+## Accessing properties
 
 Because all default properties of `Theme` are optional,
 accessing them requires the usage of a [`get` function](/api#get) or conditional chaining.
 You can let Theme UI know about [your exact theme type](#extending-the-theme),
 so you don't have to use `get` nor `.?` operator.
+
+This is also useful when the theme object is provided by the user and kept in the database,
+or in general only known at runtime.
 
 ```tsx
 /** @jsxImportSource theme-ui */
@@ -85,6 +93,21 @@ import { Theme, get } from 'theme-ui'
 
 // No error
 return <div sx={{ size: (t) => get(t, 'space.3') + get(t, 'sizes.5') }} />
+```
+
+Or with the `useThemeUI` hook:
+
+```tsx
+/** @jsxImportSource theme-ui */
+
+import { get, useThemeUI } from 'theme-ui'
+
+const CustomComponent = () => {
+  const { theme } = useThemeUI();
+  const primaryDark = get(theme, 'colors.primary-dark')
+  // primaryDark === 'darkred'
+  // ...
+}
 ```
 
 Properties of scales can be accessed with optional chaining.

--- a/packages/docs/src/pages/guides/typescript.mdx
+++ b/packages/docs/src/pages/guides/typescript.mdx
@@ -10,56 +10,60 @@ While most APIs in Theme UI should _just work_ in TypeScript,
 there are a few advanced use cases which will differ slightly.
 This guide is intended to cover those use cases.
 
-## Exact theme type
+## Extending the Theme
 
-The [`Theme` type](/theme-spec) represents all possible themes.
-
-It might be what you need when you're writing a library of reusable components
-or an app where the theme object is provided by the user and kept in the database.
-However, it's not the most convenient way to think about the theme,
-when building a blog or a landing page.
-
-To know the exact type of your particular theme on type level,
-you can use an identity "constructor" function to narrow the type.
+If you need additional properties in the theme object,
+you can add them with [module augmentation](https://www.typescriptlang.org/docs/handbook/declaration-merging.html#module-augmentation).
 
 ```tsx
-const makeTheme = <T extends Theme>(t: T) => t
+import { makeTheme } from '@theme-ui/css';
+
+interface MyTheme {
+  colors: {
+    primary: string;
+    'primary-dark': string;
+    'primary-light': string;
+  }
+}
+
+declare module '@theme-ui/css' {
+  interface UserTheme extends MyTheme {}
+}
 
 const theme = makeTheme({
   colors: {
-    background: 'white',
-    text: 'black',
-    blue: {
-      light: '#187abf',
-      dark: '#235a97',
-    },
+    primary: 'red',
+    'primary-dark': 'darkred',
+    'primary-light': 'pink'
   },
 })
-
-export type ExactTheme = typeof theme
-
-// No error
-const lightBlue = theme.colors.blue.light
 ```
 
-You can then reexport `useThemeUI` hook with narrowed type.
+Theme UI’s `Theme` interface will automatically pick up customizations to the
+internal `UserTheme` so you will be free to reference your custom properties:
 
 ```tsx
-import { ContextValue } from 'theme-ui'
+import { css } from '@theme-ui/css';
 
-interface ExactContextValue extends Omit<ContextValue, 'theme'> {
-  theme: ExactTheme
-}
-
-export const useTheme = (useThemeUI as unknown) as () => ExactContextValue
+const primaryDarkColor = css({
+  color: 'primary-dark' // auto-completes and no error
+})
 ```
 
-_[Try it on CodeSandbox.](https://codesandbox.io/s/theme-ui-typescript-tips-yh8u1?file=/src/exact-theme-type.ts)_
+or
+
+```tsx
+/** @jsxImportSource theme-ui */
+
+const H2 = () => <h2 sx={{ color: 'primary' }}>primary heading</h2>
+````
 
 ## Accessing optional properties
 
-Because all properties of `Theme` are optional,
-accessing them requires usage of [`get` function](/api#get).
+Because all default properties of `Theme` are optional,
+accessing them requires the usage of a [`get` function](/api#get) or conditional chaining.
+You can let Theme UI know about [your exact theme type](#extending-the-theme),
+so you don't have to use `get` nor `.?` operator.
 
 ```tsx
 /** @jsxImportSource theme-ui */
@@ -93,37 +97,12 @@ const parse = (x: unknown) => parseInt(String(x))
 
 return (
   <div sx={{
-    size: size: (t) => parse(t.space?.[3]) + parse(t.sizes?.[5]) }}
+    size: (t) => parse(t.space?.[3]) + parse(t.sizes?.[5]) }}
   />
 )
 ```
 
 _[Try it on CodeSandbox.](https://codesandbox.io/s/theme-ui-typescript-tips-yh8u1?file=/src/App.tsx)_
-
-## Additional properties in the theme
-
-If you need additional properties in theme object,
-you can add them with [declaration merging](https://www.typescriptlang.org/docs/handbook/declaration-merging.html#merging-interfaces).
-
-```tsx
-interface MySyntaxHighlightingTheme {
-  foreground: string
-}
-
-declare module 'theme-ui' {
-  interface Theme {
-    syntaxHighlighting: MySyntaxHighlightingTheme
-  }
-}
-
-const theme: Theme = {
-  syntaxHighlighting: {
-    foreground: '#222',
-  },
-}
-
-const syntaxHighlighting = theme.syntaxHighlighting
-```
 
 _[Try it in TypeScript Playground.](https://www.typescriptlang.org/v2/en/play?#code/JYWwDg9gTgLgBAbzgFQBYFMTrgXzgMyghDgHIYMsBaAV2FIG4AoJ4AOxnSnwEMBjbAFkAngGVhHHgA8AEsADmqADYLUMdvLSZsCJnALR08ojTYATAFxwAzjCgbmOFmfR8lPKNhAQzNJdnJKdFp6RD04dk5ufmwtLDD9fWsJGGk5RRVFdTZ5KxFxSVlVTLUNOPRwpycmPgg2WzgKbStyuABeBJsUtOLVbNzO-XxDYwhTSzIAYgAmWdIAGkqmHGYauobkwvTlPo12xqCAOk3UoozdnLX6+C4iKH2mrGPhGDYe86yNJiA)_
 


### PR DESCRIPTION
I felt like it made sense to merge "Exact theme type" and "Additional properties in the theme" into a single "Extending the Theme".

This is an initial draft as I haven't tested any of this myself, but based on #1090 and my own experience this is how I expect it will work.